### PR TITLE
Fix validate-list.js path

### DIFF
--- a/scripts/validate-list.js
+++ b/scripts/validate-list.js
@@ -20,7 +20,7 @@ const updatedList = await page.evaluate(() => {
 })
 
 for (const { name, type } of updatedList) {
-    if (! fs.existsSync(`maps/${name}.map`)) {
+    if (! fs.existsSync(`../maps/${name}.map`)) {
         console.warn(`Map ${name} - ${type} is missing!`)
     }
 }


### PR DESCRIPTION
#### This PR fixes the validation, the fs path was previously wrong and passed as if all maps were missing, now it actually passes those that do not exist